### PR TITLE
Add support to start local server for accepting OAuth access code.

### DIFF
--- a/snsapi/server.py
+++ b/snsapi/server.py
@@ -1,0 +1,53 @@
+"""A simple web server to handle OAuth 2.0 redirects.
+
+Partial code taken from google api python client.
+see: https://code.google.com/p/google-api-python-client/source/browse/oauth2client/tools.py
+Original author: jcgregorio@google.com (Joe Gregorio)
+"""
+
+import BaseHTTPServer
+import socket
+import sys
+try:
+  from urlparse import parse_qsl
+except ImportError:
+  from cgi import parse_qsl
+
+
+class ClientRedirectServer(BaseHTTPServer.HTTPServer):
+  """A server to handle OAuth 2.0 redirects back to localhost.
+
+  Waits for a single request and parses the query parameters
+  into query_params and then stops serving.
+  """
+  query_params = {}
+
+
+class ClientRedirectHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+  """A handler for OAuth 2.0 redirects back to localhost.
+
+  Waits for a single request and parses the query parameters
+  into the servers query_params and then stops serving.
+  """
+
+  def do_GET(s):
+    """Handle a GET request.
+
+    Parses the query parameters and prints a message
+    if the flow has completed. Note that we can't detect
+    if an error occurred.
+    """
+    s.send_response(200)
+    s.send_header("Content-type", "text/html")
+    s.end_headers()
+    query = s.path.split('?', 1)[-1]
+    query = dict(parse_qsl(query))
+    s.server.query_params = query
+    s.wfile.write("<html><head><title>Authentication Status</title></head>")
+    s.wfile.write("<body><p>The authentication flow has completed.</p>")
+    s.wfile.write("</body></html>")
+
+  def log_message(self, format, *args):
+    """Do not log messages to stdout while running as command line program."""
+    pass
+


### PR DESCRIPTION
To enable this function, just change the channel["auth_info"]["cmd_fetch_code"] to "local_webserver", and point the callback url to http://localhost:12121/(or https://snsapi.ie.cuhk.edu.hk/aux/auth.php to do the redirection). Code is written in a much ad hoc way, and need further organization.
