### PR TITLE
Add the app 'clock' to the project README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ SNSAPI_CONSOLE_STDOUT_ENCODING = 'gbk'
    [https://github.com/hupili/snsapi/tree/master/app/hellosns](https://github.com/hupili/snsapi/tree/master/app/hellosns).
    hello SNS将向你展示怎样用10行代码完成与SNS交互的基本功能，
    它就是利用SNSAPI开发app的hello world啦。
+   * clock: 
+   [https://github.com/hupili/snsapi/tree/master/app/clock](https://github.com/hupili/snsapi/tree/master/app/clock).
+   clock是一口SNS平台上的钟，你可以很方便的用它来定时发布消息。
    * forwarder: 
    [https://github.com/hupili/snsapi/tree/master/app/forwarder](https://github.com/hupili/snsapi/tree/master/app/forwarder).
    forwarder可以把一个平台的信息自动地发送到其他


### PR DESCRIPTION
As you developed four apps in the path snsapi/app/, only three of them are involved in the project README.md, why not add the app 'clock'?? It is a simple and clear example, too.

By the way, you needn't wirte the .md file like [http://...](http://...), just http://... in the .md and the Markdown will consider it as an URL.
