### PR TITLE
snsapi: 'platform' missing in rss channel config

### DIFF
--- a/snsapi/plugin/rss.py
+++ b/snsapi/plugin/rss.py
@@ -73,6 +73,7 @@ class RSS(SNSBase):
     @staticmethod
     def new_channel(full = False):
         c = SNSBase.new_channel(full)
+        c['platform'] = 'RSS'
         c['url'] = 'https://github.com/hupili/snsapi/commits/master.atom'
 
         return c
@@ -144,6 +145,12 @@ class RSS2RW(RSS):
         # default parameter for writing RSS2 feeds
         self.author = "snsapi"
         self.entry_timeout = 3600 #in seconds, default 1 hour
+
+    @staticmethod
+    def new_channel(full = False):
+        c = RSS.new_channel(full)
+        c['platform'] = 'RSS2RW'
+        return c
 
     def read_channel(self, channel):
         super(RSS2RW, self).read_channel(channel)


### PR DESCRIPTION
this is found when debugging tkinter ui
