### PR TITLE
Shorturl

### DIFF
--- a/snsapi/plugin/sina.py
+++ b/snsapi/plugin/sina.py
@@ -208,6 +208,27 @@ class SinaWeiboStatus(SNSBase):
         return statuslist
 
     @require_authed
+    def _short_url_weibo(self, url):
+        gurl = 'https://api.weibo.com/2/short_url/shorten.json?url_long=%s' % urllib.quote(url)
+        gurl = gurl + "&access_token=" + self.token.access_token
+        req = urllib2.Request(gurl, data='')
+        req.add_header('User_Agent', 'toolbar')
+        results = json.load(urllib2.urlopen(req))
+        return results["urls"][0]["url_short"]
+
+    @require_authed
+    def _replace_with_short_url(self, text):
+        p = re.compile("[a-zA-z]+://[^\s]*")
+        lst = p.findall(text)
+        result = text
+        for c in lst:
+            ex_c = self._expand_url(c);
+            surl = self._short_url_weibo(ex_c)
+            result = result.replace(c,surl)
+        return result
+
+
+    @require_authed
     def update(self, text):
         '''update a status
         @param text: the update message
@@ -215,6 +236,8 @@ class SinaWeiboStatus(SNSBase):
         '''
 
         text = self._cat(self.jsonconf['text_length_limit'], [(text,1)])
+        self._replace_with_short_url(text)
+
 
         url = "https://api.weibo.com/2/statuses/update.json"
         params = {}

--- a/snsapi/snsbase.py
+++ b/snsapi/snsbase.py
@@ -451,6 +451,20 @@ class SNSBase(object):
             return s.encode('utf-8') 
         else:
             return s
+
+    def _expand_url(self, url):
+		'''
+		expand a shorten url
+		
+		:param url
+				The url will be expanded if it is a shorten url, or it will 				return the origin url string. url should contain the protocol
+				like "http://"
+		'''
+		ex_url = urllib.urlopen(url)
+		if ex_url.url == url:
+			return ex_url.url
+		else:
+			return self._expand_url(ex_url.url)
     
     def _cat(self, length, text_list):
         '''


### PR DESCRIPTION
1.expand a short url is realized by _expand_url() in snsbase.py

2.short an url is realized by _short_url_weibo() in sina.py (if an url is shorten, it will be expanded)
3.detet all urls and short them is realized by _replace_with_short_url() in sina.py
4.update() is changed. It will call _replace_with_short_url() at the beginning

_expand_url() can expand any short url.
2,3,4 are only for sina weibo
Actually, when you send an url to sina weibo, it will short it automatically. If you send a short url shorten by t.cn, it will expand it to the destination and short it with t.cn.

So short an url is no meaning for sina weibo, but we may use it to short an url and send to other plantform.
