### PR TITLE
expand and short an url (short is just for sina)

### DIFF
--- a/snsapi/snsbase.py
+++ b/snsapi/snsbase.py
@@ -452,6 +452,20 @@ class SNSBase(object):
         else:
             return s
     
+    def _expand_url(self, url):
+		'''
+		expand a shorten url
+		
+		:param url
+				The url will be expanded if it is a shorten url, or it will 				return the origin url string. url should contain the protocol
+				like "http://"
+		'''
+		ex_url = urllib.urlopen(url)
+		if ex_url.url == url:
+			return ex_url.url
+		else:
+			return self._expand_url(ex_url.url)
+
     def _cat(self, length, text_list):
         '''
         Concatenate strings. 

--- a/tests/test_snsbase.py
+++ b/tests/test_snsbase.py
@@ -81,3 +81,12 @@ class TestSNSBase(TestBase):
         self._parse_code_ok('http://copy.the.code.to.client/?code=b5ffaed78a284a55e81ffe142c4771d9', 'b5ffaed78a284a55e81ffe142c4771d9')
         # Tencent example
         self._parse_code_ok('http://copy.the.code.to.client/?code=fad92807419b5aac433c4128A05e1Cad&openid=921CFC3AF04d76FE59D98a2029D0B978&openkey=6C2FCABD153B18625BAAB1BA206EF2C6', 'fad92807419b5aac433c4128A05e1Cad')
+    
+    def _expand_url_ok(self, url, code):
+        sns = SNSBase()
+        ex_url = sns._expand_url(url)
+        eq_(ex_url, code)
+    
+    def test__expand_url(self):
+        #Sina short url
+        self._expand_url_ok("http://t.cn/h51yw","http://www.google.com.hk/")


### PR DESCRIPTION
1.expand a short url is realized by _expand_url() in snsbase.py and an unit test is added

2.short an url is realized by _short_url_weibo() in sina.py (if an url is shorten, it will be expanded)
3.detecting all urls in text and shorting them is realized by _replace_with_short_url() in sina.py
4.update() is changed. It will call _replace_with_short_url() at the beginning (before _cat() )

_expand_url() can expand any short url.
but 2,3,4 are only for sina weibo
Actually, when you send an url to sina weibo, it will short it automatically. If you send a short url shorten by t.cn, it will expand it to the destination and short it with t.cn.

So short an url is no meaning for sina weibo, but we may use it to short an url and send to other plantform.
